### PR TITLE
Fix: Use /usr/bin/env bash for better portability.

### DIFF
--- a/vet
+++ b/vet
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # SPDX-FileCopyrightText: 2025-present Artem Lykhvar and contributors
 #


### PR DESCRIPTION
Replaces the hard-coded #!/bin/bash shebang to improve portability on systems like BSD where bash is located in /usr/local/bin."

Credit to u/gumnos on Reddit for the suggestion.