### PR TITLE
fix(worker): handle case-insensitive user-agent for wget

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,8 +9,9 @@ const INSTALL_SCRIPT_URL = `https://raw.githubusercontent.com/${GITHUB_REPO}/mai
 export default {
     async fetch(request) {
         const userAgent = request.headers.get("User-Agent") || "";
+        const userAgentLower = userAgent.toLowerCase();
 
-        if (userAgent.includes("curl") || userAgent.includes("wget")) {
+        if (userAgentLower.includes("curl") || userAgentLower.includes("wget")) {
             const scriptResponse = await fetch(INSTALL_SCRIPT_URL);
             return new Response(scriptResponse.body, {
                 headers: { "Content-Type": "text/plain; charset=utf-8" },


### PR DESCRIPTION
The user-agent check was case-sensitive and failed to detect the 'Wget' user-agent, causing the server to incorrectly return HTML instead of the installer script.

This fix converts the user-agent string to lowercase before the check, ensuring both 'curl' and 'wget' are correctly identified and served the plain-text script.

Credit to the Hacker News community for identifying this bug.