### PR TITLE
fix(workflow): provide install.sh directly as release asset

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release create ${{ github.ref_name }} ./vet \
+          gh release create ${{ github.ref_name }} ./vet ./scripts/install.sh \
             --title "Release ${{ github.ref_name }}" \
             --generate-notes

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ curl -o install_vet.sh https://getvet.sh
 ```
 *Option B: Direct GitHub Release Link*
 ```bash
-curl -o install_vet.sh https://github.com/vet-run/vet/releases/latest/download/vet
+curl -o install_vet.sh https://github.com/vet-run/vet/releases/latest/download/install.sh
 ```
 2. **Review the installer's code.** Open it in a text editor or use less to ensure it's not doing anything suspicious. It's a simple script that downloads the correct vet script and moves it to /usr/local/bin.
 ```bash

--- a/public/index.html
+++ b/public/index.html
@@ -155,7 +155,7 @@
         </div>
         <p>Option B: Direct GitHub Release Link</p>
         <div class="install-box">
-<pre><code>curl -o install_vet.sh https://github.com/vet-run/vet/releases/latest/download/vet</code></pre>
+<pre><code>curl -o install_vet.sh https://github.com/vet-run/vet/releases/latest/download/install.sh</code></pre>
         </div>
       </li>
       <li>


### PR DESCRIPTION
Previously, install.sh was only accessible from the official project domain or from repository source. This change modifies the release workflow to upload install.sh as a release asset, making it easier for users to download and use directly.

This improves usability for users who want to install the tool directly from GitHub.