### PR TITLE
fix(worker): use explicit URL path for installer script

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Choose one of the following sources. The first is the official project domain, a
 
 *Option A: Official project domain*
 ```bash
-curl -o install_vet.sh https://getvet.sh
+curl -o install_vet.sh https://getvet.sh/install.sh
 ```
 *Option B: Direct GitHub Release Link*
 ```bash
@@ -69,7 +69,7 @@ Congratulations! You just manually performed the process that vet will now autom
 ```bash
 # This is the curl-to-bash pattern.
 # Don't actually do this. That's the whole point.
-curl -sL https://getvet.sh | bash
+curl -sL https://getvet.sh/install.sh | bash
 ```
 ---
 ### Usage

--- a/public/index.html
+++ b/public/index.html
@@ -151,7 +151,7 @@
         <p>Choose one of the following sources. The first is the official project domain, and the second is a direct link to the GitHub release asset.</p>
         <p>Option A: Official project domain</p>
         <div class="install-box">
-<pre><code>curl -o install_vet.sh https://getvet.sh</code></pre>
+<pre><code>curl -o install_vet.sh https://getvet.sh/install.sh</code></pre>
         </div>
         <p>Option B: Direct GitHub Release Link</p>
         <div class="install-box">
@@ -176,7 +176,7 @@
     <p>In your terminal, run:</p>
     <div class="install-box">
 <pre><code class="comment"># Don't actually do this. That's the whole point.</code>
-<code>curl -sL https://getvet.sh | sh</code></pre>
+<code>curl -sL https://getvet.sh/install.sh | sh</code></pre>
     </div>
 
     <div class="footer">

--- a/src/index.js
+++ b/src/index.js
@@ -7,11 +7,10 @@ const PROMO_PAGE_URL = `https://raw.githubusercontent.com/${GITHUB_REPO}/main/pu
 const INSTALL_SCRIPT_URL = `https://raw.githubusercontent.com/${GITHUB_REPO}/main/scripts/install.sh`;
 
 export default {
-    async fetch(request) {
-        const userAgent = request.headers.get("User-Agent") || "";
-        const userAgentLower = userAgent.toLowerCase();
+    async fetch(request, env, ctx) {
+        const url = new URL(request.url);
 
-        if (userAgentLower.includes("curl") || userAgentLower.includes("wget")) {
+        if (url.pathname === "/install.sh") {
             const scriptResponse = await fetch(INSTALL_SCRIPT_URL);
             return new Response(scriptResponse.body, {
                 headers: { "Content-Type": "text/plain; charset=utf-8" },
@@ -19,10 +18,14 @@ export default {
             });
         }
 
-        const promoResponse = await fetch(PROMO_PAGE_URL);
-        return new Response(promoResponse.body, {
-            headers: { "Content-Type": "text/html; charset=utf-8" },
-            status: promoResponse.status,
-        });
+        if (url.pathname === "/") {
+            const promoResponse = await fetch(PROMO_PAGE_URL);
+            return new Response(promoResponse.body, {
+                headers: { "Content-Type": "text/html; charset=utf-8" },
+                status: promoResponse.status,
+            });
+        }
+
+        return new Response("Not Found", { status: 404 });
     },
 };


### PR DESCRIPTION
Switches from fragile User-Agent sniffing to path-based routing (/install.sh) to serve the installer script. This fixes a critical bug where users with a custom .curlrc would incorrectly receive the HTML page instead of the script.

All documentation has been updated to reflect the new, explicit URL.

Credit to GitHub user @hkdobrev for the excellent bug report.