### PR TITLE
docs: fix install instructions to handle GitHub release redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ curl -o install_vet.sh https://getvet.sh/install.sh
 ```
 *Option B: Direct GitHub Release Link*
 ```bash
-curl -o install_vet.sh https://github.com/vet-run/vet/releases/latest/download/install.sh
+curl -L -o install_vet.sh https://github.com/vet-run/vet/releases/latest/download/install.sh
 ```
 2. **Review the installer's code.** Open it in a text editor or use less to ensure it's not doing anything suspicious. It's a simple script that downloads the correct vet script and moves it to /usr/local/bin.
 ```bash

--- a/public/index.html
+++ b/public/index.html
@@ -155,7 +155,7 @@
         </div>
         <p>Option B: Direct GitHub Release Link</p>
         <div class="install-box">
-<pre><code>curl -o install_vet.sh https://github.com/vet-run/vet/releases/latest/download/install.sh</code></pre>
+<pre><code>curl -L -o install_vet.sh https://github.com/vet-run/vet/releases/latest/download/install.sh</code></pre>
         </div>
       </li>
       <li>


### PR DESCRIPTION
Updated install instructions so that users can properly fetch the script from GitHub Releases, which uses redirects.