### PR TITLE
Suggest and use less -U when showing script for review

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,9 +67,9 @@ curl -o install_vet.sh https://getvet.sh/install.sh
 ```bash
 curl -L -o install_vet.sh https://github.com/vet-run/vet/releases/latest/download/install.sh
 ```
-2. **Review the installer's code.** Open it in a text editor or use less to ensure it's not doing anything suspicious. It's a simple script that downloads the correct vet script and moves it to /usr/local/bin.
+2. **Review the installer's code.** Open it in a text editor or use `less -U` to ensure it's not doing anything suspicious. It's a simple script that downloads the correct vet script and moves it to /usr/local/bin.
 ```bash
-less install_vet.sh
+less -U install_vet.sh
 ```
 3. **Run the installer you just vetted:**
 ```bash

--- a/vet
+++ b/vet
@@ -137,7 +137,7 @@ if [ -f "$CACHE_FILE_PATH" ]; then
         printf "[?] %sShow diff?%s [y/N] " "$C_BOLD" "$C_RESET"
         read -n 1 -r REPLY; echo
         if [[ "$REPLY" =~ ^[Yy]$ ]]; then
-            less "$TMPFILE_DIFF"
+            less -U "$TMPFILE_DIFF"
         fi
     fi
 fi
@@ -184,7 +184,7 @@ if [ -t 0 ]; then
         if [ -n "$BAT_CMD" ]; then
             "$BAT_CMD" -l sh --paging=always "$TMPFILE"
         else
-            less "$TMPFILE"
+            less -U "$TMPFILE"
         fi
     fi
     printf "[?] %sExecute this script?%s [y/N] " "$C_BOLD" "$C_RESET"


### PR DESCRIPTION
Without -U it is possible to use characters like backspace (^H) to hide the real script.

For example:

```
$ printf '#!/bin/sh\necho i am evil #\b\b\b\b\b\b\b\b\b\b\bhello world\n' > evil.sh
$ less evil.sh
[shows "hello world"]
$ sh evil.sh
i am evil
```

(I've previously covered some of this in research like https://dgl.cx/term. There's no security reporting instructions in the repo, so I'm reporting publicly with a fix, as this doesn't seem critical.)