### PR TITLE
closed

### DIFF
--- a/vet
+++ b/vet
@@ -39,6 +39,7 @@ OPTIONS:
     -f, --force     Skip all interactive prompts and execute immediately.
                     Use with extreme caution in trusted environments.
     -h, --help      Display this help message.
+    -n, --netrc     Use ~/.netrc credentials for authentication.
 EOF
 }
 
@@ -59,6 +60,14 @@ check_dependencies() {
     fi
 }
 
+build_authentication() {
+    # Tell curl to check ~./netrc for authentication credentials.
+    if [[ "${DOWNLOAD_CMD[0]}" == "curl" ]]; then
+        NETRC="${NETRC:-}"
+        [[ ! "$NETRC" ]] && NETRC_ARG=() || NETRC_ARG=(-n)
+    fi
+}
+
 trap cleanup EXIT INT TERM
 
 FORCE_MODE=0
@@ -72,6 +81,10 @@ while [[ $# -gt 0 ]]; do
         -h|--help)
             usage
             exit 0
+            ;;
+        -n|--netrc)
+            NETRC=1
+            shift
             ;;
         --)
             shift
@@ -100,13 +113,14 @@ shift
 SCRIPT_ARGS=("$@")
 
 check_dependencies
+build_authentication
 
 mkdir -p "$CACHE_DIR"
 TMPFILE=$(mktemp) || { log_error "Failed to create temporary file."; exit 1; }
 TMPFILE_DIFF=$(mktemp) || { log_error "Failed to create temporary diff file."; exit 1; }
 
 log_info "Downloading script from: $URL"
-if ! "${DOWNLOAD_CMD[@]}" "$TMPFILE" "$URL"; then
+if ! "${DOWNLOAD_CMD[@]}" "$TMPFILE" "$URL" "${NETRC_ARG[@]}"; then
     log_error "Download failed. Check URL and network connection."
     exit 1
 fi

--- a/vet
+++ b/vet
@@ -40,6 +40,8 @@ OPTIONS:
                     Use with extreme caution in trusted environments.
     -h, --help      Display this help message.
     -n, --netrc     Use ~/.netrc credentials for authentication.
+    -t, --token-stdin
+                    Set authentication token from standard input.
 EOF
 }
 
@@ -88,6 +90,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         -n|--netrc)
             NETRC=1
+            shift
+            ;;
+        -t|--token-stdin)
+            IFS= read -r VET_TOKEN
             shift
             ;;
         --)

--- a/vet
+++ b/vet
@@ -61,11 +61,15 @@ check_dependencies() {
 }
 
 build_authentication() {
-    # Tell curl to check ~./netrc for authentication credentials.
+    # Tell curl to check ~/.netrc for authentication credentials.
     if [[ "${DOWNLOAD_CMD[0]}" == "curl" ]]; then
         NETRC="${NETRC:-}"
         [[ ! "$NETRC" ]] && NETRC_ARG=() || NETRC_ARG=(-n)
     fi
+
+    # Build Authorization header, if token exists.
+    VET_TOKEN="${VET_TOKEN:-}"
+    [[ ! "$VET_TOKEN" ]] && AUTH_HEADER=() || AUTH_HEADER=(--header "Authorization: bearer $VET_TOKEN")
 }
 
 trap cleanup EXIT INT TERM
@@ -120,7 +124,7 @@ TMPFILE=$(mktemp) || { log_error "Failed to create temporary file."; exit 1; }
 TMPFILE_DIFF=$(mktemp) || { log_error "Failed to create temporary diff file."; exit 1; }
 
 log_info "Downloading script from: $URL"
-if ! "${DOWNLOAD_CMD[@]}" "$TMPFILE" "$URL" "${NETRC_ARG[@]}"; then
+if ! "${DOWNLOAD_CMD[@]}" "$TMPFILE" "$URL" "${AUTH_HEADER[@]}" "${NETRC_ARG[@]}"; then
     log_error "Download failed. Check URL and network connection."
     exit 1
 fi

--- a/vet
+++ b/vet
@@ -64,9 +64,10 @@ check_dependencies() {
 
 build_authentication() {
     # Tell curl to check ~/.netrc for authentication credentials.
+    NETRC="${NETRC:-}"
+    [[ ! "$NETRC" ]] && NETRC_ARG=()
     if [[ "${DOWNLOAD_CMD[0]}" == "curl" ]]; then
-        NETRC="${NETRC:-}"
-        [[ ! "$NETRC" ]] && NETRC_ARG=() || NETRC_ARG=(-n)
+        NETRC_ARG=(-n)
     fi
 
     # Build Authorization header, if token exists.

--- a/vet
+++ b/vet
@@ -94,7 +94,9 @@ while [[ $# -gt 0 ]]; do
             shift
             ;;
         -t|--token-stdin)
-            IFS= read -r VET_TOKEN
+            if [[ ! -t 0 ]]; then
+                IFS= read -r VET_TOKEN
+            fi
             shift
             ;;
         --)


### PR DESCRIPTION
This PR adds support for authentication via ~/.netrc credentials, environment variable, and standard input.

Notes: 
- wget vs netrc: from my research wget should "just work" out of the box if a ~/.netrc file exists, however, I was not able to get it to work on my wget version (GNU Wget 1.21.3) independent of vet.  The curl -n works fine with the same file.  Some testing from someone else for wget netrc support?  

If this looks like an acceptable approach I will update documentation and tests.
