### PR TITLE
add authentication support for private repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,38 @@ Skip all interactive prompts and execute immediately. Use with caution.
 
 Display the help message.
 
+\-n, \--netrc
+
+Use ~/.netrc credentials for authentication.
+
+\-t, \--token-stdin
+
+Set authentication token from standard input.
+
+#### Authentication
+
+`vet` can:
+
+-   Read from a `~/.netrc` file.
+```
+# Example ~/.netrc file to authenticate with GitHub private repositories
+machine raw.githubusercontent.com
+login api
+password <YOUR_GITHUB_PERSONAL_ACCESS_TOKEN>
+```
+
+-   Detect and read a `$VET_TOKEN` from an environment variable into an `Authorization` token.
+```bash
+# Example setting a VET_TOKEN from an environment variable for private GitHub repository access
+export VET_TOKEN=<YOUR_GITHUB_PERSONAL_ACCESS_TOKEN>
+```
+
+-   Read an `Authorization` token from standard input.
+```bash
+# Example setting a VET_TOKEN from standared input for private GitHub repository access
+echo <YOUR_GITHUB_PERSONAL_ACCESS_TOKEN> | ./vet --token-stdin https://example.com/private.sh
+```
+
 ## Project Philosophy & Technical Decisions
 
 ### Bash 4+ is a Required Dependency

--- a/vet
+++ b/vet
@@ -39,6 +39,9 @@ OPTIONS:
     -f, --force     Skip all interactive prompts and execute immediately.
                     Use with extreme caution in trusted environments.
     -h, --help      Display this help message.
+    -n, --netrc     Use ~/.netrc credentials for authentication.
+    -t, --token-stdin
+                    Set authentication token from standard input.
 EOF
 }
 
@@ -59,6 +62,20 @@ check_dependencies() {
     fi
 }
 
+build_authentication() {
+    # Tell curl to check ~/.netrc for authentication credentials.
+    # wget checks for existence of ~/.netrc by default
+    NETRC="${NETRC:-}"
+    [[ ! "$NETRC" ]] && NETRC_ARG=()
+    if [[ "${DOWNLOAD_CMD[0]}" == "curl" ]]; then
+        NETRC_ARG=(-n)
+    fi
+
+    # Build Authorization header, if token exists.
+    VET_TOKEN="${VET_TOKEN:-}"
+    [[ ! "$VET_TOKEN" ]] && AUTH_HEADER=() || AUTH_HEADER=(--header "Authorization: bearer $VET_TOKEN")
+}
+
 trap cleanup EXIT INT TERM
 
 FORCE_MODE=0
@@ -72,6 +89,16 @@ while [[ $# -gt 0 ]]; do
         -h|--help)
             usage
             exit 0
+            ;;
+        -n|--netrc)
+            NETRC=1
+            shift
+            ;;
+        -t|--token-stdin)
+            if [[ ! -t 0 ]]; then
+                IFS= read -r VET_TOKEN
+            fi
+            shift
             ;;
         --)
             shift
@@ -100,13 +127,14 @@ shift
 SCRIPT_ARGS=("$@")
 
 check_dependencies
+build_authentication
 
 mkdir -p "$CACHE_DIR"
 TMPFILE=$(mktemp) || { log_error "Failed to create temporary file."; exit 1; }
 TMPFILE_DIFF=$(mktemp) || { log_error "Failed to create temporary diff file."; exit 1; }
 
 log_info "Downloading script from: $URL"
-if ! "${DOWNLOAD_CMD[@]}" "$TMPFILE" "$URL"; then
+if ! "${DOWNLOAD_CMD[@]}" "$TMPFILE" "$URL" "${AUTH_HEADER[@]}" "${NETRC_ARG[@]}"; then
     log_error "Download failed. Check URL and network connection."
     exit 1
 fi


### PR DESCRIPTION
support for ~/.netrc
support for environment variable
support for stdin

notes:

I was not able to confirm that wget, independent of vet, could read my ~/.netrc file despite it being used successfully by curl. I was testing on wget 1.21.3 debian bookworm, so maybe someone else can verify that please.

re: issue #4 