### PR TITLE
fix(ci): Disable shellcheck error SC2329

### DIFF
--- a/vet
+++ b/vet
@@ -42,7 +42,7 @@ OPTIONS:
 EOF
 }
 
-# shellcheck disable=SC2317
+# shellcheck disable=SC2317,SC2329
 cleanup() {
     [ -n "${TMPFILE:-}" ] && [ -f "${TMPFILE}" ] && rm -f "${TMPFILE}"
     [ -n "${TMPFILE_DIFF:-}" ] && [ -f "${TMPFILE_DIFF}" ] && rm -f "${TMPFILE_DIFF}"


### PR DESCRIPTION
Disable `shellcheck` warning for trap handler `cleanup` function, which is a known limitation of static analysis and results in a false positive warning.